### PR TITLE
pycharm.desktop: Don't create multiple icons in Gnome Shell

### DIFF
--- a/pycharm.desktop
+++ b/pycharm.desktop
@@ -7,3 +7,4 @@ Icon=pycharm
 Type=Application
 Categories=Development;
 X-Desktop-File-Install-Version=0.21
+StartupWMClass=jetbrains-pycharm-ce


### PR DESCRIPTION
Adding a 'StartupWMClass' line in `pycharm.desktop` prevents Gnome Shell from showing two icons for the launched application; see http://askubuntu.com/a/635839. The correct class can be obtained using `xprop WM_CLASS`.