### PR TITLE
Update to Pycharm 5.0.2

### DIFF
--- a/pycharm-community.spec
+++ b/pycharm-community.spec
@@ -13,7 +13,7 @@
 %endif
 
 Name:          pycharm-community
-Version:       5.0.1
+Version:       5.0.2
 Release:       1%{?dist}
 Summary:       Intelligent Python IDE
 Group:         Development/Tools
@@ -74,6 +74,9 @@ desktop-file-install                          \
 %{_bindir}/pycharm
 
 %changelog
+* Fri Dec 11 2015 Allan Lewis <allanlewis@users.noreply.github.com> - 5.0.2-1
+- update to the latest version, 5.0.2
+
 * Tue Nov 17 2015 Allan Lewis <allanlewis@users.noreply.github.com> - 5.0.1-1
 - update to the latest version, 5.0.1
 


### PR DESCRIPTION
Pycharm 5.0.2 was released yesterday: http://blog.jetbrains.com/pycharm/2015/12/pycharm-5-0-2-update-released-along-with-new-jetbrains-branding/

I've tested the build on Fedora 21: it build and installs fine. However, the "Help > About" dialog still says 5.0.1: ![](https://cloud.githubusercontent.com/assets/194736/11744010/4e5ccbd0-a004-11e5-9ba5-869465fc2699.png)
I've raised a ticket for this: https://youtrack.jetbrains.com/issue/PY-17940