### PR TITLE
pycharm-community.spec: Remove 32-bit binaries to avoid dependency on 32-bit libc

### DIFF
--- a/pycharm-community.spec
+++ b/pycharm-community.spec
@@ -49,6 +49,7 @@ mkdir -p %{buildroot}%{_datadir}/appdata
 mkdir -p %{buildroot}%{_bindir}
 
 cp -arf ./{lib,bin,help,helpers,plugins} %{buildroot}%{_javadir}/%{name}/
+rm -f %{buildroot}%{_javadir}/%{name}/bin/fsnotifier{,-arm}
 # this will be in docs
 rm -f %{buildroot}%{_javadir}/help/*.pdf
 cp -af ./bin/pycharm.png %{buildroot}%{_datadir}/pixmaps/pycharm.png


### PR DESCRIPTION
Installing on Fedora 21, the package currently pulls in 32-bit `glibc` as well as 64-bit because `bin/fsnotifier` and `bin/fsnotifier-arm` are 32-bit binaries. I'm not sure the solution presented here is the best, but if we define this COPR as 64-bit only, it might be OK. Otherwise, we need to detect bit-ness and delete the inappropriate binaries, or just ignore their dependencies.

I've tested this build on Fedora 21; I suggest testing it on current versions before merging.