### PR TITLE
Ignore downloaded plugin archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 pycharm-community-*.tar.gz
 results/
+/*.zip
+/*.jar


### PR DESCRIPTION
We now download plugin archives to the root directory. This PR updates `.gitignore` to ignore these files so that running `./build.sh` leaves a clean repo.