### PR TITLE
Add patches for `pytest.mark.parametrize`

### DIFF
--- a/pycharm-community-pytest-init-whitespace.patch
+++ b/pycharm-community-pytest-init-whitespace.patch
@@ -1,0 +1,68 @@
+diff --git a/helpers/python-skeletons/pytest/__init__.py b/helpers/python-skeletons/pytest/__init__.py
+index ae4549f..5d51a7e 100644
+--- a/helpers/python-skeletons/pytest/__init__.py
++++ b/helpers/python-skeletons/pytest/__init__.py
+@@ -76,11 +76,11 @@ class mark:
+         value.
+ 
+         Optionally specify a reason for better reporting.
+-        
+-        Evaluation happens within the module global context. 
++
++        Evaluation happens within the module global context.
+         Example: ``skipif('sys.platform == "win32"')`` skips the test if
+         we are on the win32 platform.
+-        
++
+         see http://pytest.org/latest/skipping.html
+         """
+ 
+@@ -88,15 +88,15 @@ class mark:
+     def xfail(condition=None, reason=None, run=True):
+         """mark the the test function as an expected failure if eval(condition)
+         has a True value.
+-        
++
+         Optionally specify a reason for better reporting and run=False if
+         you don't even want to execute the test function.
+-        
++
+         See http://pytest.org/latest/skipping.html
+         """
+ 
+     @staticmethod
+-    def parametrize(argnames, argvalues): 
++    def parametrize(argnames, argvalues):
+         """call a test function multiple times passing in different arguments
+         in turn.
+ 
+@@ -113,14 +113,14 @@ class mark:
+         """
+ 
+     @staticmethod
+-    def usefixtures(*fixturenames): 
+-        """mark tests as needing all of the specified fixtures. 
+-        
++    def usefixtures(*fixturenames):
++        """mark tests as needing all of the specified fixtures.
++
+         see http://pytest.org/latest/fixture.html#usefixtures
+         """
+ 
+     @staticmethod
+-    def tryfirst(f): 
++    def tryfirst(f):
+         """mark a hook implementation function such that the plugin machinery
+         will try to call it first/as early as possible.
+         """
+@@ -133,8 +133,8 @@ class mark:
+ 
+     @staticmethod
+     def hookwrapper(f):
+-        """A hook wrapper is a generator function which yields exactly once. 
+-        When pytest invokes hooks it first executes hook wrappers and passes 
++        """A hook wrapper is a generator function which yields exactly once.
++        When pytest invokes hooks it first executes hook wrappers and passes
+         the same arguments as to the regular hooks.
+         """
+ 

--- a/pycharm-community-pytest-parametrize.patch
+++ b/pycharm-community-pytest-parametrize.patch
@@ -1,0 +1,38 @@
+diff --git a/helpers/python-skeletons/pytest/__init__.py b/helpers/python-skeletons/pytest/__init__.py
+index 5d51a7e..e487e4f 100644
+--- a/helpers/python-skeletons/pytest/__init__.py
++++ b/helpers/python-skeletons/pytest/__init__.py
+@@ -96,7 +96,7 @@ class mark:
+         """
+
+     @staticmethod
+-    def parametrize(argnames, argvalues):
++    def parametrize(argnames, argvalues, indirect=False, ids=None, scope=None):
+         """call a test function multiple times passing in different arguments
+         in turn.
+
+@@ -105,6 +105,25 @@ class mark:
+         specifies only one name or a list of tuples of values if
+         argnames specifies multiple names.
+
++        :param indirect: The list of argnames or boolean. A list of arguments'
++        names (subset of argnames). If True the list contains all names from the
++        argnames. Each argvalue corresponding to an argname in this list will be
++        passed as request.param to its respective argname fixture function so
++        that it can perform more expensive setups during the setup phase of a
++        test rather than at collection time.
++
++        :param ids: list of string ids, or a callable. If strings, each is
++        corresponding to the argvalues so that they are part of the test id. If
++        callable, it should take one argument (a single argvalue) and return a
++        string or return None. If None, the automatically generated id for that
++        argument will be used. If no ids are provided they will be generated
++        automatically from the argvalues.
++
++        :param scope: if specified it denotes the scope of the parameters. The
++        scope is used for grouping tests by parameter instances. It will also
++        override any fixture-function defined scope, allowing to set a dynamic
++        scope using test context or configuration.
++
+         Example: @parametrize('arg1', [1,2]) would lead to two calls of the
+         decorated test function, one with arg1=1 and another with arg1=2.

--- a/pycharm-community.spec
+++ b/pycharm-community.spec
@@ -28,7 +28,7 @@
 
 Name:          pycharm-community
 Version:       2016.1.4
-Release:       5%{?dist}
+Release:       6%{?dist}
 Summary:       Intelligent Python IDE
 Group:         Development/Tools
 License:       ASL 2.0
@@ -62,6 +62,8 @@ Source101:     pycharm.xml
 Source102:     pycharm.desktop
 Source103:     pycharm-community.appdata.xml
 Patch1:        pycharm-community-MaxPermSize.patch
+Patch2:        pycharm-community-pytest-init-whitespace.patch
+Patch3:        pycharm-community-pytest-parametrize.patch
 BuildRequires: desktop-file-utils
 BuildRequires: python2-devel
 %if %{with python3}
@@ -87,6 +89,8 @@ Intellij Ansible, GitLab integration plugin.
 %prep
 %setup -q -n %{name}-%{version}
 %patch1 -p1
+%patch2 -p1
+%patch3 -p1
 %setup -q -n %{name}-%{version} -D -T -a 1
 %setup -q -n %{name}-%{version} -D -T -a 2
 %setup -q -n %{name}-%{version} -D -T -a 3
@@ -205,6 +209,9 @@ desktop-file-install                          \
 %{_javadir}/%{name}/%{plugins_dir}/ini4idea/*
 
 %changelog
+* Wed Jul 13 2016 Allan Lewis <allanlewis99@gmail.com> - 2016.1.4-6
+- Patch Pytest 'parametrize' skeleton to match Pytest 2.9.2.
+
 * Wed Jul 13 2016 Petr Hracek <phracek@redhat.com> - 2016.1.4-5
 - Fix %exlude syntax
 


### PR DESCRIPTION
PyCharm provides skeletons for autocompleting various Pytest functions; I
assume it does this because a lot of Pytest's code is dynamically imported and
therefore difficult for PyCharm to inspect. One such function is `parametrize`,
which is used to define parametrised tests. The signature of this function has
been extended since PyCharm last updated their skeleton. This commit adds a
patch to amend the relevant file. It also adds a pre-patch that normalises
trailing whitespace in the same file, for ease of editing.

I intend to raise a pull request upstream with JetBrains/intellij-community, 
but there's currently a GitHub issue preventing me from forking that 
repository.