### PR TITLE
pycharm-community.spec: Update to the latest version, 2017.1.3

### DIFF
--- a/pycharm-community.spec
+++ b/pycharm-community.spec
@@ -50,7 +50,7 @@
 %global markdown_version 0.9.7
 
 Name:          pycharm-community
-Version:       2017.1.2
+Version:       2017.1.3
 Release:       1%{?dist}
 Summary:       Intelligent Python IDE
 License:       ASL 2.0
@@ -201,6 +201,9 @@ fi
 %license license/
 
 %changelog
+* Tue May 30 2017 Allan Lewis <allanlewis99@gmail.com> - 2017.1.3-1
+- Update to latest upstream version, 2017.1.3.
+
 * Tue May 02 2017 Allan Lewis <allanlewis99@gmail.com> - 2017.1.2-1
 - Update to latest upstream version, 2017.1.2.
 


### PR DESCRIPTION
This has been sanity-tested on Fedora 25 (with the latest updates).