### PR TITLE
Revert addition of global variable for top-level archive directory

### DIFF
--- a/pycharm-community.spec
+++ b/pycharm-community.spec
@@ -51,7 +51,7 @@
 
 Name:          pycharm-community
 Version:       2017.2.1
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       Intelligent Python IDE
 License:       ASL 2.0
 URL:           http://www.jetbrains.com/pycharm/
@@ -201,6 +201,9 @@ fi
 %license license/
 
 %changelog
+* Thu Aug 10 2017 Allan Lewis <allanlewis99@gmail.com> - 2017.2.1-2
+- Revert top-level archive directory change as upstream archive has been fixed.
+
 * Wed Aug 09 2017 Allan Lewis <allanlewis99@gmail.com> - 2017.2.1-1
 - Update to latest upstream version, 2017.2.1.
 

--- a/pycharm-community.spec
+++ b/pycharm-community.spec
@@ -103,23 +103,20 @@ Intellij Ansible, GitLab integration plugin.
 %description doc
 This package contains documentation for Intelligent Python IDE.
 
-# This should be '%{name}-%{version}' but it's wrong in v2017.2.1
-%global builddir %{name}-2017.2
-
 %prep
-%setup -q -n %{builddir}
-%setup -q -n %{builddir} -D -T -a 1
-%setup -q -n %{builddir} -D -T -a 2
-%setup -q -n %{builddir} -D -T -a 3
-%setup -q -n %{builddir} -D -T -a 4
-%setup -q -n %{builddir} -D -T -a 5
-%setup -q -n %{builddir} -D -T -a 6
-%setup -q -n %{builddir} -D -T -a 7
-%setup -q -n %{builddir} -D -T -a 8
-%setup -q -n %{builddir} -D -T -a 9
-%setup -q -n %{builddir} -D -T -a 10
-%setup -q -n %{builddir} -D -T -a 11
-%setup -q -n %{builddir} -D -T -a 12
+%setup -q -n %{name}-%{version}
+%setup -q -n %{name}-%{version} -D -T -a 1
+%setup -q -n %{name}-%{version} -D -T -a 2
+%setup -q -n %{name}-%{version} -D -T -a 3
+%setup -q -n %{name}-%{version} -D -T -a 4
+%setup -q -n %{name}-%{version} -D -T -a 5
+%setup -q -n %{name}-%{version} -D -T -a 6
+%setup -q -n %{name}-%{version} -D -T -a 7
+%setup -q -n %{name}-%{version} -D -T -a 8
+%setup -q -n %{name}-%{version} -D -T -a 9
+%setup -q -n %{name}-%{version} -D -T -a 10
+%setup -q -n %{name}-%{version} -D -T -a 11
+%setup -q -n %{name}-%{version} -D -T -a 12
 
 %install
 mkdir -p %{buildroot}%{_javadir}/%{name}


### PR DESCRIPTION
The upstream issue has been fixed, so the change introduced in #40 can be reverted.