### PR TITLE
Add build.txt to the output directory

### DIFF
--- a/pycharm-community.spec
+++ b/pycharm-community.spec
@@ -167,7 +167,7 @@ mkdir -p %{buildroot}%{_datadir}/applications
 mkdir -p %{buildroot}%{_datadir}/metainfo
 mkdir -p %{buildroot}%{_bindir}
 
-cp -arf ./{lib,bin,help,helpers,plugins} %{buildroot}%{_javadir}/%{name}/
+cp -arf ./{lib,bin,help,helpers,plugins,build.txt} %{buildroot}%{_javadir}/%{name}/
 %ifarch x86_64
 cp -arf ./jre64 %{buildroot}%{_javadir}/%{name}/
 %endif


### PR DESCRIPTION
This will fix the plugin compatibility issues.

Without this file, PyCharm wasn't able to determine its own version, so the loading was failed for the plugins with the `until` version filter (`<idea-version until="191.*" />`).