### PR TITLE
Add aarch64 conditional source

### DIFF
--- a/pycharm-community.spec
+++ b/pycharm-community.spec
@@ -26,7 +26,11 @@ Summary:       Intelligent Python IDE
 License:       Apache-2.0
 URL:           https://www.jetbrains.com/%{appname}/
 
+%ifarch x86_64
 Source0:       https://download.jetbrains.com/python/%{name}-%{version}.tar.gz
+%else
+Source0:       https://download.jetbrains.com/python/%{name}-%{version}-%{_arch}.tar.gz
+%endif
 
 Source101:     %{name}.xml
 Source102:     %{name}.desktop
@@ -47,7 +51,7 @@ BuildRequires: javapackages-filesystem
 Requires:      javapackages-filesystem
 %endif
 
-ExclusiveArch: x86_64
+ExclusiveArch: x86_64 aarch64
 
 Obsoletes:     %{name}-jre < %{?epoch:%{epoch}:}%{version}-%{release}
 

--- a/pycharm-community.spec
+++ b/pycharm-community.spec
@@ -19,7 +19,7 @@
 %global __requires_exclude_from %{_javadir}/%{name}/jbr/.*|%{_javadir}/%{name}/lib/.*|%{_javadir}/%{name}/plugins/.*
 
 Name:          %{appname}-community
-Version:       2023.1.4
+Version:       2023.3.2
 Release:       1%{?dist}
 
 Summary:       Intelligent Python IDE
@@ -115,6 +115,13 @@ install -m 0644 -p %{SOURCE102} %{buildroot}%{_datadir}/applications/%{name}.des
 # Installing mime package...
 install -d %{buildroot}%{_datadir}/mime/packages
 install -m 0644 -p %{SOURCE101} %{buildroot}%{_datadir}/mime/packages/%{name}.xml
+
+# Patch Python shebangs
+tail -n +2 %{buildroot}%{_datadir}/java/pycharm-community/plugins/python-ce/helpers/pycodestyle-2.10.0.py
+sed -i '1 i #!/usr/bin/env python3' %{buildroot}%{_datadir}/java/pycharm-community/plugins/python-ce/helpers/pycodestyle-2.10.0.py
+
+tail -n +2 %{buildroot}%{_datadir}/java/pycharm-community/plugins/python-ce/helpers/pycodestyle.py
+sed -i '1 i #!/usr/bin/env python3' %{buildroot}%{_datadir}/java/pycharm-community/plugins/python-ce/helpers/pycodestyle.py
 
 %check
 appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/%{name}.metainfo.xml


### PR DESCRIPTION
Pycharm distributes aarch64 tarballs by inserting `-aarch64` between version and extension.

Therefore, I don't see an issue to build for two architectures. Not sure about the plugins though, which are marked as `skipped` in COPR.

https://copr.fedorainfracloud.org/coprs/nsella/pycharm-community-edition-aarch64/builds/